### PR TITLE
Add CIFuzz

### DIFF
--- a/.github/workflow/cifuzz.yml
+++ b/.github/workflow/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Fuzzers
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'dragonfly'
+          dry-run: false
+          language: go
+      - name: Run Fuzzers
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'dragonfly'
+          fuzz-seconds: 600
+          dry-run: false
+          language: go
+      - name: Upload Crash
+        uses: actions/upload-artifact@v1
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: artifacts
+          path: ./out/artifacts


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/dragonflyoss/dragonfly/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
Added CIFuzz which will run Dragonflys fuzzers for 600 seconds in the CI when a PR is made.

CIFuzz is a service by OSS-fuzz for integrated projects. Documentation can be found here: https://google.github.io/oss-fuzz/getting-started/continuous-integration/

Dragonflys fuzzers can be found here:

- https://github.com/dragonflyoss/Dragonfly/blob/master/dfget/core/uploader/uploader_fuzz.go
- https://github.com/dragonflyoss/Dragonfly/blob/master/supernode/daemon/mgr/cdn/cdn_fuzz.go

Dragonflys OSS-fuzz integration can be found here: https://github.com/google/oss-fuzz/tree/master/projects/dragonfly


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
No


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
No new Go code has been added.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


